### PR TITLE
feat: implement mdx posts and infinite scroll

### DIFF
--- a/content/post01.mdx
+++ b/content/post01.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 01"
+date: "2024-01-01"
+---
+
+# Post 01
+
+Content of post 01.

--- a/content/post02.mdx
+++ b/content/post02.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 02"
+date: "2024-01-02"
+---
+
+# Post 02
+
+Content of post 02.

--- a/content/post03.mdx
+++ b/content/post03.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 03"
+date: "2024-01-03"
+---
+
+# Post 03
+
+Content of post 03.

--- a/content/post04.mdx
+++ b/content/post04.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 04"
+date: "2024-01-04"
+---
+
+# Post 04
+
+Content of post 04.

--- a/content/post05.mdx
+++ b/content/post05.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 05"
+date: "2024-01-05"
+---
+
+# Post 05
+
+Content of post 05.

--- a/content/post06.mdx
+++ b/content/post06.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 06"
+date: "2024-01-06"
+---
+
+# Post 06
+
+Content of post 06.

--- a/content/post07.mdx
+++ b/content/post07.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 07"
+date: "2024-01-07"
+---
+
+# Post 07
+
+Content of post 07.

--- a/content/post08.mdx
+++ b/content/post08.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 08"
+date: "2024-01-08"
+---
+
+# Post 08
+
+Content of post 08.

--- a/content/post09.mdx
+++ b/content/post09.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 09"
+date: "2024-01-09"
+---
+
+# Post 09
+
+Content of post 09.

--- a/content/post10.mdx
+++ b/content/post10.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 10"
+date: "2024-01-10"
+---
+
+# Post 10
+
+Content of post 10.

--- a/content/post11.mdx
+++ b/content/post11.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 11"
+date: "2024-01-11"
+---
+
+# Post 11
+
+Content of post 11.

--- a/content/post12.mdx
+++ b/content/post12.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 12"
+date: "2024-01-12"
+---
+
+# Post 12
+
+Content of post 12.

--- a/content/post13.mdx
+++ b/content/post13.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 13"
+date: "2024-01-13"
+---
+
+# Post 13
+
+Content of post 13.

--- a/content/post14.mdx
+++ b/content/post14.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 14"
+date: "2024-01-14"
+---
+
+# Post 14
+
+Content of post 14.

--- a/content/post15.mdx
+++ b/content/post15.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 15"
+date: "2024-01-15"
+---
+
+# Post 15
+
+Content of post 15.

--- a/content/post16.mdx
+++ b/content/post16.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 16"
+date: "2024-01-16"
+---
+
+# Post 16
+
+Content of post 16.

--- a/content/post17.mdx
+++ b/content/post17.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 17"
+date: "2024-01-17"
+---
+
+# Post 17
+
+Content of post 17.

--- a/content/post18.mdx
+++ b/content/post18.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 18"
+date: "2024-01-18"
+---
+
+# Post 18
+
+Content of post 18.

--- a/content/post19.mdx
+++ b/content/post19.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 19"
+date: "2024-01-19"
+---
+
+# Post 19
+
+Content of post 19.

--- a/content/post20.mdx
+++ b/content/post20.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 20"
+date: "2024-01-20"
+---
+
+# Post 20
+
+Content of post 20.

--- a/content/post21.mdx
+++ b/content/post21.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 21"
+date: "2024-01-21"
+---
+
+# Post 21
+
+Content of post 21.

--- a/content/post22.mdx
+++ b/content/post22.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 22"
+date: "2024-01-22"
+---
+
+# Post 22
+
+Content of post 22.

--- a/content/post23.mdx
+++ b/content/post23.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 23"
+date: "2024-01-23"
+---
+
+# Post 23
+
+Content of post 23.

--- a/content/post24.mdx
+++ b/content/post24.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 24"
+date: "2024-01-24"
+---
+
+# Post 24
+
+Content of post 24.

--- a/content/post25.mdx
+++ b/content/post25.mdx
@@ -1,0 +1,8 @@
+---
+title: "Post 25"
+date: "2024-01-25"
+---
+
+# Post 25
+
+Content of post 25.

--- a/src/__tests__/scrollFetchMore.test.js
+++ b/src/__tests__/scrollFetchMore.test.js
@@ -1,0 +1,11 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { getPostsPage } from '../lib/posts.js';
+
+test('fetch more posts', () => {
+  const first = getPostsPage(0, 20);
+  assert.strictEqual(first.length, 20);
+  const second = getPostsPage(1, 20);
+  assert.strictEqual(second.length, 5);
+  assert.notStrictEqual(first[0].slug, second[0].slug);
+});

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,0 +1,12 @@
+import { getPostsPage, getAllPosts } from '../../../lib/posts.js';
+
+export async function GET(req) {
+  const url = new URL(req.url, 'http://localhost');
+  const page = Number(url.searchParams.get('page') || '0');
+  const limit = 20;
+  const posts = getPostsPage(page, limit);
+  const total = getAllPosts().length;
+  return new Response(JSON.stringify({ posts, total }), {
+    headers: { 'Content-Type': 'application/json' }
+  });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,14 @@
+import PostsList from '../components/PostsList.js';
+import { getPostsPage, getAllPosts } from '../lib/posts.js';
+
 export default function Page() {
-  return <h1 className="text-2xl font-bold">Hello Next 15</h1>;
+  const initial = getPostsPage(0, 20);
+  const total = getAllPosts().length;
+  return (
+    <main>
+      <h1 className="text-2xl font-bold">Latest Posts</h1>
+      {/* @ts-expect-error Server Component */}
+      <PostsList initialPosts={initial} totalCount={total} />
+    </main>
+  );
 }

--- a/src/components/Mdx.js
+++ b/src/components/Mdx.js
@@ -1,0 +1,3 @@
+export default function Mdx({ html }: { html: string }) {
+  return <div dangerouslySetInnerHTML={{ __html: html }} />;
+}

--- a/src/components/PostsList.js
+++ b/src/components/PostsList.js
@@ -1,0 +1,40 @@
+'use client';
+import { useEffect, useRef, useState } from 'react';
+
+export default function PostsList({ initialPosts, totalCount }) {
+  const [posts, setPosts] = useState(initialPosts);
+  const page = useRef(0);
+  const sentinelRef = useRef(null);
+
+  useEffect(() => {
+    const io = new IntersectionObserver(entries => {
+      if (posts.length >= totalCount) return;
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          fetch(`/api/posts?page=${page.current + 1}`)
+            .then(r => r.json())
+            .then(data => {
+              setPosts(p => [...p, ...data.posts]);
+              page.current += 1;
+            });
+        }
+      });
+    });
+    const s = sentinelRef.current;
+    if (s) io.observe(s);
+    return () => {
+      if (s) io.unobserve(s);
+    };
+  }, [posts.length, totalCount]);
+
+  return (
+    <div>
+      <ul>
+        {posts.map(post => (
+          <li key={post.slug}>{post.title}</li>
+        ))}
+      </ul>
+      <div data-testid="sentinel" ref={sentinelRef} />
+    </div>
+  );
+}

--- a/src/lib/posts.js
+++ b/src/lib/posts.js
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import path from 'path';
+
+function simpleMarkdownToHtml(markdown) {
+  return markdown
+    .replace(/```([\s\S]*?)```/g, '<pre><code>$1</code></pre>')
+    .replace(/^# (.*)$/gm, '<h1>$1</h1>')
+    .replace(/^## (.*)$/gm, '<h2>$1</h2>')
+    .replace(/\[(.*?)\]\((.*?)\)/g, '<a href="$2">$1</a>')
+    .replace(/\n/g, '<br/>');
+}
+
+function parseFrontMatter(file) {
+  const match = /---\n([\s\S]*?)\n---/.exec(file);
+  const meta = {};
+  if (match) {
+    match[1].split('\n').forEach(line => {
+      const [key, ...rest] = line.split(':');
+      if (key && rest.length) meta[key.trim()] = rest.join(':').trim().replace(/^"|"$/g, '');
+    });
+  }
+  const result = {
+    title: meta.title || 'No title',
+    date: meta.date || '1970-01-01',
+    slug: meta.slug || ''
+  };
+  return result;
+}
+
+const CONTENT_DIR = path.join(process.cwd(), 'content');
+
+export function getAllPosts() {
+  return fs
+    .readdirSync(CONTENT_DIR)
+    .filter(f => f.endsWith('.mdx'))
+    .map(f => {
+      const full = fs.readFileSync(path.join(CONTENT_DIR, f), 'utf-8');
+      const meta = parseFrontMatter(full);
+      return { ...meta, slug: f.replace(/\.mdx$/, '') };
+    })
+    .sort((a, b) => (a.date < b.date ? 1 : -1));
+}
+
+export function getPost(slug) {
+  const file = fs.readFileSync(path.join(CONTENT_DIR, `${slug}.mdx`), 'utf-8');
+  const meta = parseFrontMatter(file);
+  const body = file.replace(/^[\s\S]*?\n---\n/, '').trim();
+  const html = simpleMarkdownToHtml(body);
+  return { meta, html };
+}
+
+export function getPostsPage(page, limit) {
+  const all = getAllPosts();
+  return all.slice(page * limit, (page + 1) * limit);
+}

--- a/src/types/PostMeta.ts
+++ b/src/types/PostMeta.ts
@@ -1,0 +1,5 @@
+export interface PostMeta {
+  title: string;
+  date: string;
+  slug: string;
+}


### PR DESCRIPTION
## Goal
- load `.mdx` articles and paginate them
- show the first 20 posts and fetch more on scroll
- provide a unit test for the pagination helper

## Summary
- added `PostMeta` type and utility functions to parse front‑matter
- created a client `PostsList` component using `IntersectionObserver`
- API route returns paginated posts
- server homepage feeds initial posts to the client list
- updated unit test for pagination

## Acceptance Criteria
- [x] Latest posts show first 20 titles
- [x] `Fetch More` logic loads next posts
- [x] `pnpm test` passes
- [x] `pnpm build` succeeds